### PR TITLE
Implement CommandOption for Id<AttachmentMarker>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Implemented `Attachment` command option type. (by @Lyssieth)
+
 ## [0.9.0] - 2022-01-24
 ### Changed
 - Updated to `twilight-model` 0.9.

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -8,6 +8,7 @@ use twilight_model::{
             InteractionChannel, InteractionMember,
         },
     },
+    channel::Attachment,
     guild::Role,
     id::{
         marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
@@ -488,6 +489,21 @@ impl CommandOption for Id<AttachmentMarker> {
             CommandOptionValue::Attachment(value) => Ok(value),
             other => Err(ParseOptionErrorType::InvalidType(other.kind())),
         }
+    }
+}
+
+impl CommandOption for Attachment {
+    fn from_option(
+        value: CommandOptionValue,
+        _data: CommandOptionData,
+        resolved: Option<&CommandInteractionDataResolved>,
+    ) -> Result<Self, ParseOptionErrorType> {
+        let attachment_id = match value {
+            CommandOptionValue::Attachment(value) => value,
+            other => return Err(ParseOptionErrorType::InvalidType(other.kind())),
+        };
+
+        lookup!(resolved.attachments, attachment_id)
     }
 }
 

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     },
     guild::Role,
     id::{
-        marker::{ChannelMarker, GenericMarker, RoleMarker, UserMarker},
+        marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
         Id,
     },
     user::User,
@@ -473,6 +473,19 @@ impl CommandOption for Id<GenericMarker> {
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Mentionable(value) => Ok(value),
+            other => Err(ParseOptionErrorType::InvalidType(other.kind())),
+        }
+    }
+}
+
+impl CommandOption for Id<AttachmentMarker> {
+    fn from_option(
+        value: CommandOptionValue,
+        _data: CommandOptionData,
+        _resolved: Option<&CommandInteractionDataResolved>,
+    ) -> Result<Self, ParseOptionErrorType> {
+        match value {
+            CommandOptionValue::Attachment(value) => Ok(value),
             other => Err(ParseOptionErrorType::InvalidType(other.kind())),
         }
     }

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -5,7 +5,7 @@ use twilight_model::{
     },
     guild::Role,
     id::{
-        marker::{ChannelMarker, GenericMarker, RoleMarker, UserMarker},
+        marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
         Id,
     },
     user::User,
@@ -223,6 +223,12 @@ impl CreateOption for Id<RoleMarker> {
 impl CreateOption for Id<GenericMarker> {
     fn create_option(data: CreateOptionData) -> CommandOption {
         CommandOption::Mentionable(data.into_data())
+    }
+}
+
+impl CreateOption for Id<AttachmentMarker> {
+    fn create_option(data: CreateOptionData) -> CommandOption {
+        CommandOption::Attachment(data.into_data())
     }
 }
 

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -3,6 +3,7 @@ use twilight_model::{
         command::{Command, CommandOption, CommandType, Number, OptionsCommandOptionData},
         interaction::application_command::InteractionChannel,
     },
+    channel::Attachment,
     guild::Role,
     id::{
         marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
@@ -227,6 +228,12 @@ impl CreateOption for Id<GenericMarker> {
 }
 
 impl CreateOption for Id<AttachmentMarker> {
+    fn create_option(data: CreateOptionData) -> CommandOption {
+        CommandOption::Attachment(data.into_data())
+    }
+}
+
+impl CreateOption for Attachment {
     fn create_option(data: CreateOptionData) -> CommandOption {
         CommandOption::Attachment(data.into_data())
     }

--- a/twilight-interactions/src/command/mod.rs
+++ b/twilight-interactions/src/command/mod.rs
@@ -52,6 +52,8 @@
 //! [`Role`]: twilight_model::guild::Role
 //! [`RoleId`]: twilight_model::id::RoleId
 //! [`GenericId`]: twilight_model::id::GenericId
+//! [`Attachment`]: twilight_model::channel::Attachment
+//! [`AttachmentId`]: twilight_model::id::AttachmentId
 
 mod command_model;
 mod create_command;

--- a/twilight-interactions/src/command/mod.rs
+++ b/twilight-interactions/src/command/mod.rs
@@ -34,12 +34,13 @@
 //! |---------------------|----------------------------------------|
 //! | `STRING`            | [`String`]                             |
 //! | `INTEGER`           | [`i64`]                                |
-//! | `NUMBER`            | [`Number`], [`f64`]
+//! | `NUMBER`            | [`Number`], [`f64`]                    |
 //! | `BOOLEAN`           | [`bool`]                               |
 //! | `USER`              | [`ResolvedUser`], [`User`], [`UserId`] |
 //! | `CHANNEL`           | [`InteractionChannel`], [`ChannelId`]  |
 //! | `ROLE`              | [`Role`], [`RoleId`]                   |
 //! | `MENTIONABLE`       | [`GenericId`]                          |
+//! | `ATTACHMENT`        | [`Attachment`], [`AttachmentId`]       |
 //!
 //! [`from_interaction`]: CommandModel::from_interaction
 //!

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -79,6 +79,7 @@ fn test_command_model() {
         roles: HashMap::new(),
         users: hashmap! { user_id => user.clone() },
         messages: HashMap::new(),
+        attachments: HashMap::new(),
     };
 
     let data = CommandInputData {


### PR DESCRIPTION
This implements `CommandOption` for `Id<AttachmentMarker`, since Attachments are now valid for slash commands, to bring this once again up to parity with `twilight` itself.

This also makes the test pass in the simplest way possible, just by making an empty HashMap.