### PR TITLE
 Upgrade to twilight 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgraded to `twilight-model` 0.10.0
+
 ## [0.9.1] - 2022-03-09
 ### Changed
 - Implemented `Attachment` command option type. (by @Lyssieth)

--- a/README.md
+++ b/README.md
@@ -45,5 +45,4 @@ The API documentation is available on docs.rs: [`twilight-interactions` document
 ## Contributing
 There is no particular contribution guidelines, feel free to open a new PR to improve the code. If you want to introduce a new feature, please create an issue before.
 
-
 *Special thanks to [LeSeulArtichaut](https://github.com/LeSeulArtichaut) who worked the first on this project.*

--- a/twilight-interactions/Cargo.toml
+++ b/twilight-interactions/Cargo.toml
@@ -19,7 +19,7 @@ default = ["derive"]
 derive = ["twilight-interactions-derive"]
 
 [dependencies]
-twilight-model = "0.9"
+twilight-model = "0.10"
 twilight-interactions-derive = { version = "=0.9.1", path = "../twilight-interactions-derive", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This seemed to be a very simple upgrade, and I wanted to get my bot upgraded, so I'm submitting this PR :3

`cargo nextest` saw the tests run well, and after I enabled actions in my fork that worked fine too.

note: it seems I accidentally edited a line in the readme; my markdown formatter doesn't like your markdown formatting (I use vscode and `Markdown All In One` + `markdownlint`)