### PR TITLE
Allow CommandModel and CreateCommand types to have generics

### DIFF
--- a/twilight-interactions-derive/src/command/model/command_model.rs
+++ b/twilight-interactions-derive/src/command/model/command_model.rs
@@ -9,6 +9,8 @@ use super::parse::{FieldType, StructField};
 /// Implementation of CommandModel derive macro
 pub fn impl_command_model(input: DeriveInput, fields: Option<FieldsNamed>) -> Result<TokenStream> {
     let ident = &input.ident;
+    let generics = &input.generics;
+    let where_clause = &generics.where_clause;
     let fields = match fields {
         Some(fields) => StructField::from_fields(fields)?,
         None => Vec::new(),
@@ -20,7 +22,7 @@ pub fn impl_command_model(input: DeriveInput, fields: Option<FieldsNamed>) -> Re
     let fields_constructor = fields.iter().map(field_constructor);
 
     Ok(quote! {
-        impl ::twilight_interactions::command::CommandModel for #ident {
+        impl #generics ::twilight_interactions::command::CommandModel for #ident #generics #where_clause {
             fn from_interaction(
                 data: ::twilight_interactions::command::CommandInputData,
             ) -> ::std::result::Result<Self, ::twilight_interactions::error::ParseError> {

--- a/twilight-interactions-derive/src/command/model/create_command.rs
+++ b/twilight-interactions-derive/src/command/model/create_command.rs
@@ -9,6 +9,8 @@ use super::parse::{channel_type, command_option_value, StructField, TypeAttribut
 /// Implementation of CreateCommand derive macro
 pub fn impl_create_command(input: DeriveInput, fields: Option<FieldsNamed>) -> Result<TokenStream> {
     let ident = &input.ident;
+    let generics = &input.generics;
+    let where_clause = &generics.where_clause;
     let span = input.span();
     let fields = match fields {
         Some(fields) => StructField::from_fields(fields)?,
@@ -44,7 +46,7 @@ pub fn impl_create_command(input: DeriveInput, fields: Option<FieldsNamed>) -> R
         .collect::<Result<Vec<_>>>()?;
 
     Ok(quote! {
-        impl ::twilight_interactions::command::CreateCommand for #ident {
+        impl #generics ::twilight_interactions::command::CreateCommand for #ident #generics #where_clause {
             const NAME: &'static str = #name;
 
             fn create_command() -> ::twilight_interactions::command::ApplicationCommandData {

--- a/twilight-interactions-derive/src/command/subcommand/command_model.rs
+++ b/twilight-interactions-derive/src/command/subcommand/command_model.rs
@@ -10,12 +10,14 @@ pub fn impl_command_model(
     variants: impl IntoIterator<Item = Variant>,
 ) -> Result<TokenStream> {
     let ident = &input.ident;
+    let generics = &input.generics;
+    let where_clause = &generics.where_clause;
     let variants = ParsedVariant::from_variants(variants, input.span())?;
 
     let variants_match_arms = variants.iter().map(variant_match_arm);
 
     Ok(quote! {
-        impl ::twilight_interactions::command::CommandModel for #ident {
+        impl #generics ::twilight_interactions::command::CommandModel for #ident #generics #where_clause {
             fn from_interaction(
                 data: ::twilight_interactions::command::CommandInputData,
             ) -> ::std::result::Result<Self, ::twilight_interactions::error::ParseError> {

--- a/twilight-interactions-derive/src/command/subcommand/create_command.rs
+++ b/twilight-interactions-derive/src/command/subcommand/create_command.rs
@@ -12,6 +12,8 @@ pub fn impl_create_command(
     variants: impl IntoIterator<Item = Variant>,
 ) -> Result<TokenStream> {
     let ident = &input.ident;
+    let generics = &input.generics;
+    let where_clause = &generics.where_clause;
     let span = input.span();
 
     let variants = ParsedVariant::from_variants(variants, input.span())?;
@@ -36,7 +38,7 @@ pub fn impl_create_command(
     let variant_options = variants.iter().map(variant_option);
 
     Ok(quote! {
-        impl ::twilight_interactions::command::CreateCommand for #ident {
+        impl #generics ::twilight_interactions::command::CreateCommand for #ident #generics #where_clause {
             const NAME: &'static str = #name;
 
             fn create_command() -> ::twilight_interactions::command::ApplicationCommandData {

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use maplit::hashmap;
-use twilight_interactions::command::{CommandInputData, CommandModel, ResolvedUser};
+use twilight_interactions::command::{CommandInputData, CommandModel, CommandOption, ResolvedUser};
 use twilight_model::{
     application::interaction::application_command::{
         CommandDataOption, CommandInteractionDataResolved, CommandOptionValue, InteractionMember,
@@ -13,11 +13,15 @@ use twilight_model::{
 };
 
 #[derive(CommandModel, Debug, PartialEq, Eq)]
-struct DemoCommand {
+struct DemoCommand<T>
+where
+    T: CommandOption,
+{
     #[command(rename = "member", desc = "test")]
     user: ResolvedUser,
     text: String,
     number: Option<i64>,
+    generic: T,
 }
 
 #[derive(CommandModel, Debug, PartialEq, Eq)]
@@ -40,6 +44,11 @@ fn test_command_model() {
         CommandDataOption {
             name: "number".into(),
             value: CommandOptionValue::Integer(42),
+            focused: false,
+        },
+        CommandDataOption {
+            name: "generic".into(),
+            value: CommandOptionValue::Integer(0),
             focused: false,
         },
     ];
@@ -97,6 +106,7 @@ fn test_command_model() {
             },
             text: "hello world".into(),
             number: Some(42),
+            generic: 0_i64,
         },
         result
     );

--- a/twilight-interactions/tests/create_command.rs
+++ b/twilight-interactions/tests/create_command.rs
@@ -1,4 +1,6 @@
-use twilight_interactions::command::{ApplicationCommandData, CreateCommand, ResolvedUser};
+use twilight_interactions::command::{
+    ApplicationCommandData, CreateCommand, CreateOption, ResolvedUser,
+};
 use twilight_model::{
     application::{
         command::{
@@ -13,7 +15,10 @@ use twilight_model::{
 /// Demo command for testing purposes
 #[derive(CreateCommand, Debug, PartialEq, Eq)]
 #[command(name = "demo")]
-struct DemoCommand {
+struct DemoCommand<T>
+where
+    T: CreateOption,
+{
     /// This should be overwritten
     #[command(rename = "member", desc = "A member")]
     user: ResolvedUser,
@@ -27,6 +32,8 @@ struct DemoCommand {
     /// A text channel
     #[command(channel_types = "guild_text private")]
     channel: Option<InteractionChannel>,
+    /// Generic field
+    generic: Option<T>,
 }
 
 #[derive(CreateCommand, Debug, PartialEq, Eq)]
@@ -63,6 +70,15 @@ fn test_create_command() {
             name: "channel".into(),
             required: false,
         }),
+        CommandOption::Integer(NumberCommandOptionData {
+            autocomplete: false,
+            choices: vec![],
+            description: "Generic field".into(),
+            max_value: None,
+            min_value: None,
+            name: "generic".into(),
+            required: false,
+        }),
     ];
 
     let expected = ApplicationCommandData {
@@ -73,8 +89,8 @@ fn test_create_command() {
         group: false,
     };
 
-    assert_eq!(DemoCommand::create_command(), expected);
-    assert_eq!(DemoCommand::NAME, "demo");
+    assert_eq!(DemoCommand::<i64>::create_command(), expected);
+    assert_eq!(DemoCommand::<i64>::NAME, "demo");
 }
 
 #[test]


### PR DESCRIPTION
The `CommandModel` and `CreateCommand` derives currently don't handle generics properly. This PR adds the generics into the token stream.