### PR TITLE
feat: update to syn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Attribute parameters names are now correctly validated. (#21)
+
+### Changed
+- Updated to `syn` 2.
 
 ## [0.15.0] - 2023-02-07
 ### Changed

--- a/twilight-interactions-derive/Cargo.toml
+++ b/twilight-interactions-derive/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = "2"


### PR DESCRIPTION
Update `syn` to version 2 ([changelog](https://github.com/dtolnay/syn/releases/tag/2.0.0)).

Breaking changes mostly affect the attribute parser logic, which has been refactored.

Fixes #21.