### PR TITLE
fix: trim spaces from macro attributes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest
     env:
-      minrust: "1.64"
+      minrust: "1.67"
 
     steps:
       - name: Checkout sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Strings are now trimmed in macro attributes to match Discord's behavior.
 
+### Changed
+- Bumped MSRV to 1.67.
+
 ## [0.15.1] - 2023-03-26
 ### Fixed
 - Attribute parameters names are now correctly validated. (#21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Strings are now trimmed in macro attributes to match Discord's behavior.
 
 ## [0.15.1] - 2023-03-26
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ twilight-interactions = "0.15"
 ```
 
 The crate's major version follows the version of the official twilight crates.
-The current MSRV is `1.64`.
+The current MSRV is `1.67`.
 
 ## Documentation
 

--- a/twilight-interactions-derive/src/parse.rs
+++ b/twilight-interactions-derive/src/parse.rs
@@ -164,7 +164,7 @@ impl AttrValue {
 
     pub fn parse_string(&self) -> Result<String> {
         match self.inner() {
-            Lit::Str(inner) => Ok(inner.value()),
+            Lit::Str(inner) => Ok(inner.value().trim().to_string()),
             _ => Err(Error::new(
                 self.0.span(),
                 "invalid attribute type, expected string",


### PR DESCRIPTION
Remove leading and trailing whitespaces in string attributes to match the Discord behavior.

Closes #23 