### PR TITLE
feat: allow boxed subcommand variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Subcommands enums now support `Box`ed variants to avoid large enums.
+
 ### Fixed
 - Strings are now trimmed in macro attributes to match Discord's behavior.
 

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -153,6 +153,12 @@ pub trait CommandModel: Sized {
     fn from_interaction(data: CommandInputData) -> Result<Self, ParseError>;
 }
 
+impl<T: CommandModel> CommandModel for Box<T> {
+    fn from_interaction(data: CommandInputData) -> Result<Self, ParseError> {
+        T::from_interaction(data).map(Box::new)
+    }
+}
+
 impl CommandModel for Vec<CommandDataOption> {
     fn from_interaction(data: CommandInputData) -> Result<Self, ParseError> {
         Ok(data.options)

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -92,6 +92,14 @@ pub trait CreateCommand: Sized {
     fn create_command() -> ApplicationCommandData;
 }
 
+impl<T: CreateCommand> CreateCommand for Box<T> {
+    const NAME: &'static str = T::NAME;
+
+    fn create_command() -> ApplicationCommandData {
+        T::create_command()
+    }
+}
+
 /// Create a command option from a type.
 ///
 /// This trait is used by the implementation of [`CreateCommand`] generated

--- a/twilight-interactions/tests/subcommand.rs
+++ b/twilight-interactions/tests/subcommand.rs
@@ -52,7 +52,7 @@ enum SubCommand {
     #[command(name = "one")]
     One(CommandOne),
     #[command(name = "group")]
-    Group(SubCommandGroup),
+    Group(Box<SubCommandGroup>),
 }
 
 fn subcommand_desc() -> [(&'static str, &'static str); 1] {
@@ -115,9 +115,9 @@ fn test_subcommand_group_model() {
     let result = SubCommand::from_interaction(data).unwrap();
 
     assert_eq!(
-        SubCommand::Group(SubCommandGroup::Three(CommandThree {
+        SubCommand::Group(Box::new(SubCommandGroup::Three(CommandThree {
             option: "test".into()
-        })),
+        }))),
         result
     );
 }


### PR DESCRIPTION
Add a generic implementation of `CommandModel` and `CreateCommand` to `Box`. This allows to box large enum variants in subcommands or subcommand groups.