### PR TITLE
Use "" as the fallback from desc locales

### DIFF
--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -14,6 +14,8 @@ use twilight_model::{
     user::User,
 };
 
+use crate::error::CreateCommandError;
+
 use super::{internal::CreateOptionData, ResolvedMentionable, ResolvedUser};
 
 /// Create a slash command from a type.
@@ -89,13 +91,13 @@ pub trait CreateCommand: Sized {
     const NAME: &'static str;
 
     /// Create an [`ApplicationCommandData`] for this type.
-    fn create_command() -> ApplicationCommandData;
+    fn create_command() -> Result<ApplicationCommandData, CreateCommandError>;
 }
 
 impl<T: CreateCommand> CreateCommand for Box<T> {
     const NAME: &'static str = T::NAME;
 
-    fn create_command() -> ApplicationCommandData {
+    fn create_command() -> Result<ApplicationCommandData, CreateCommandError> {
         T::create_command()
     }
 }

--- a/twilight-interactions/src/error.rs
+++ b/twilight-interactions/src/error.rs
@@ -7,6 +7,35 @@ use std::{
 
 use twilight_model::{application::command::CommandOptionType, channel::ChannelType};
 
+/// Error when creating a command.
+///
+/// This error type is returned by the [`CreateCommand::create_command`]
+/// method.
+///
+/// [`CreateCommand::create_command`]: crate::command::CreateCommand::create_command
+#[derive(Debug, Clone, PartialEq)]
+pub enum CreateCommandError {
+    /// No description was specified for a command.
+    NoCommandDescription(&'static str),
+    /// No description was specified for an option.
+    NoOptionDescription(&'static str),
+}
+
+impl Error for CreateCommandError {}
+
+impl Display for CreateCommandError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoCommandDescription(cmd) => {
+                write!(f, "no description specified for command {cmd}")
+            }
+            Self::NoOptionDescription(option) => {
+                write!(f, "no description was specified for option {option}")
+            }
+        }
+    }
+}
+
 /// Error when parsing a command.
 ///
 /// This error type is returned by the [`CommandModel::from_interaction`]

--- a/twilight-interactions/tests/create_command.rs
+++ b/twilight-interactions/tests/create_command.rs
@@ -53,8 +53,12 @@ fn demo_name() -> [(&'static str, &'static str); 1] {
     [("en", "demo")]
 }
 
+fn desc() -> [(&'static str, &'static str); 2] {
+    [("en", "en desc"), ("", "fallback desc")]
+}
+
 #[derive(CreateCommand, Debug, PartialEq, Eq)]
-#[command(name = "unit", desc = "Unit command for testing purposes")]
+#[command(name = "unit", desc_localizations = "desc")]
 struct UnitCommand;
 
 #[test]
@@ -172,17 +176,19 @@ fn test_create_command() {
         nsfw: Some(true),
     };
 
-    assert_eq!(DemoCommand::<i64>::create_command(), expected);
+    assert_eq!(DemoCommand::<i64>::create_command(), Ok(expected));
     assert_eq!(DemoCommand::<i64>::NAME, "demo");
 }
 
 #[test]
 fn test_unit_create_command() {
+    let desc_localizations = HashMap::from([("en".into(), "en desc".into())]);
+
     let expected = ApplicationCommandData {
         name: "unit".into(),
         name_localizations: None,
-        description: "Unit command for testing purposes".into(),
-        description_localizations: None,
+        description: "fallback desc".into(),
+        description_localizations: Some(desc_localizations),
         options: vec![],
         default_member_permissions: None,
         dm_permission: None,
@@ -190,6 +196,6 @@ fn test_unit_create_command() {
         nsfw: None,
     };
 
-    assert_eq!(UnitCommand::create_command(), expected);
+    assert_eq!(UnitCommand::create_command(), Ok(expected));
     assert_eq!(UnitCommand::NAME, "unit");
 }

--- a/twilight-interactions/tests/option_locales.rs
+++ b/twilight-interactions/tests/option_locales.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use twilight_interactions::command::{ApplicationCommandData, CreateCommand};
+use twilight_model::{
+    application::command::{CommandOption, CommandOptionType},
+    guild::Permissions,
+};
+
+/// A command
+#[derive(CreateCommand)]
+#[command(name = "demo")]
+struct Command {
+    /// Option with doc description
+    doc_option: String,
+    #[command(desc = "option with desc attribute")]
+    attr_option: String,
+    #[command(desc_localizations = "locale_option")]
+    locale_option: String,
+}
+
+fn locale_option() -> [(&'static str, &'static str); 2] {
+    [("en", "en description"), ("", "fallback description")]
+}
+
+#[test]
+fn test_option_description() {
+    let locales = HashMap::from([("en".into(), "en description".into())]);
+
+    let options = vec![
+        CommandOption {
+            autocomplete: Some(false),
+            channel_types: None,
+            choices: None,
+            description: "Option with doc description".into(),
+            description_localizations: None,
+            kind: CommandOptionType::String,
+            max_length: None,
+            max_value: None,
+            min_length: None,
+            min_value: None,
+            name: "doc_option".into(),
+            name_localizations: None,
+            options: None,
+            required: Some(true),
+        },
+        CommandOption {
+            autocomplete: Some(false),
+            channel_types: None,
+            choices: None,
+            description: "option with desc attribute".into(),
+            description_localizations: None,
+            kind: CommandOptionType::String,
+            max_length: None,
+            max_value: None,
+            min_length: None,
+            min_value: None,
+            name: "attr_option".into(),
+            name_localizations: None,
+            options: None,
+            required: Some(true),
+        },
+        CommandOption {
+            autocomplete: Some(false),
+            channel_types: None,
+            choices: None,
+            description: "fallback description".into(),
+            description_localizations: Some(locales),
+            kind: CommandOptionType::String,
+            max_length: None,
+            max_value: None,
+            min_length: None,
+            min_value: None,
+            name: "locale_option".into(),
+            name_localizations: None,
+            options: None,
+            required: Some(true),
+        },
+    ];
+
+    let expected = ApplicationCommandData {
+        name: "demo".into(),
+        name_localizations: None,
+        description: "A command".into(),
+        description_localizations: None,
+        options,
+        default_member_permissions: None,
+        dm_permission: None,
+        group: false,
+        nsfw: None,
+    };
+
+    assert_eq!(Command::create_command(), Ok(expected));
+}

--- a/twilight-interactions/tests/subcommand.rs
+++ b/twilight-interactions/tests/subcommand.rs
@@ -223,5 +223,5 @@ fn test_create_subcommand() {
         nsfw: None,
     };
 
-    assert_eq!(SubCommand::create_command(), expected);
+    assert_eq!(SubCommand::create_command(), Ok(expected));
 }


### PR DESCRIPTION
I decided to try my hand at this, since I hadn't worked with proc macros before.

This implementation uses the "" locale from the function as a fallback if there's no doc comment or desc attribute. This also means that ::create_command returns a result. The errors probably need some work.

I also added another test module for option descriptions, since that doesn't seem to be anywhere already.

I'm not sure if there's any other places where locale functions are used that could actually use this - I know that names cannot, since those are stored statically on the structs on expanding, at which point we don't have access to the HashMap of locales. Currently this handles command descriptions and option descriptions. Do choices have descriptions that would use this too?

I know you wanted to decide what implementation to use, which is fine. I wanted to do this anyways, even though there's a decent chance this won't be used. Since I actually succeeded I figured I'd open a draft pr so you could at least see it.