### PR TITLE
ci: run actions on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   msrv:
@@ -73,26 +76,26 @@ jobs:
           RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
         run: cargo doc --no-deps --all-features
 
-  cargo-deny:
-    name: Lint dependencies
-    needs: [msrv]
-    runs-on: ubuntu-latest
+  # cargo-deny:
+  #   name: Lint dependencies
+  #   needs: [msrv]
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Install cargo-deny
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-deny
+  #     - name: Install cargo-deny
+  #       uses: baptiste0928/cargo-install@v2
+  #       with:
+  #         crate: cargo-deny
 
-      - name: Lint dependencies
-        run: cargo-deny check bans licenses sources
+  #     - name: Lint dependencies
+  #       run: cargo-deny check bans licenses sources
 
-      - name: Check security advisories
-        run: cargo-deny check advisories
-        continue-on-error: true  # Avoid sudden breakages
+  #     - name: Check security advisories
+  #       run: cargo-deny check advisories
+  #       continue-on-error: true  # Avoid sudden breakages
 
   rustfmt:
     name: Format


### PR DESCRIPTION
- Enable actions on `pull_request` again (disabled in c8ec8ed23317fd0ecb3003c6d8f182e483991c1c). Run only on `push` from `main` to avoid duplicate runs, which is why they were disabled in the first place.

- Temporarily disable the `cargo-deny` step, as it causes problems with some PRs (vulnerability notifications are still handled by GitHub's Dependabot alerts).