### PR TITLE
feat!: update to twilight 0.16

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,16 +10,16 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 
 futures-util = { version = "0.3", default-features = false }
-reqwest = { version = "0.11", features = ["json"] }
-tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "ansi"], default-features = false }
 
-twilight-gateway = "0.15.2"
-twilight-http = "0.15.2"
+twilight-gateway = "=0.16.0-rc.1"
+twilight-http = "=0.16.0-rc.1"
 twilight-interactions = { path = "../twilight-interactions" }
-twilight-model = "0.15.2"
-twilight-util = { version = "0.15.2", features = ["builder"] }
+twilight-model = "=0.16.0-rc.1"
+twilight-util = { version = "=0.16.0-rc.1", features = ["builder"] }
 
 [[example]]
 name = "xkcd-bot"

--- a/twilight-interactions-derive/Cargo.toml
+++ b/twilight-interactions-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilight-interactions-derive"
-version = "0.15.2"
+version = "0.16.0-rc.1"
 description = "Macros and utilities to make Discord Interactions easy to use with Twilight."
 categories = ["parsing", "config", "asynchronous"]
 keywords = ["twilight", "discord", "slash-command"]

--- a/twilight-interactions-derive/src/option/command_option.rs
+++ b/twilight-interactions-derive/src/option/command_option.rs
@@ -37,7 +37,7 @@ pub fn impl_command_option(input: DeriveInput) -> Result<TokenStream> {
             fn from_option(
                 __value: ::twilight_model::application::interaction::application_command::CommandOptionValue,
                 __data: twilight_interactions::command::internal::CommandOptionData,
-                __resolved: ::std::option::Option<&::twilight_model::application::interaction::application_command::CommandInteractionDataResolved>
+                __resolved: ::std::option::Option<&::twilight_model::application::interaction::InteractionDataResolved>
             ) -> ::std::result::Result<Self, ::twilight_interactions::error::ParseOptionErrorType> {
                 #parsed_init
 
@@ -78,7 +78,7 @@ pub fn dummy_command_option(ident: Ident, error: Error) -> TokenStream {
             fn from_option(
                 value: ::twilight_model::application::interaction::application_command::CommandOptionValue,
                 data: ::twilight_interactions::command::internal::CommandOptionData,
-                resolved: ::std::option::Option<&::twilight_model::application::interaction::application_command::CommandInteractionDataResolved>
+                resolved: ::std::option::Option<&::twilight_model::application::interaction::InteractionDataResolved>
             ) -> ::std::result::Result<Self, ::twilight_interactions::error::ParseOptionErrorType> {
                 ::std::unimplemented!()
             }

--- a/twilight-interactions/Cargo.toml
+++ b/twilight-interactions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilight-interactions"
-version = "0.15.2"
+version = "0.16.0-rc.1"
 description = "Macros and utilities to make Discord Interactions easy to use with Twilight."
 categories = ["parsing", "config", "asynchronous"]
 keywords = ["twilight", "discord", "slash-command"]
@@ -19,8 +19,8 @@ default = ["derive"]
 derive = ["twilight-interactions-derive"]
 
 [dependencies]
-twilight-model = "0.15.0"
-twilight-interactions-derive = { version = "=0.15.2", path = "../twilight-interactions-derive", optional = true }
+twilight-model = "=0.16.0-rc.1"
+twilight-interactions-derive = { version = "=0.16.0-rc.1", path = "../twilight-interactions-derive", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use twilight_model::{
     application::{
         command::CommandOptionValue as NumberCommandOptionValue,
-        interaction::application_command::{
-            CommandData, CommandDataOption, CommandInteractionDataResolved, CommandOptionValue,
-            InteractionChannel, InteractionMember,
+        interaction::{
+            application_command::{CommandData, CommandDataOption, CommandOptionValue},
+            InteractionChannel, InteractionDataResolved, InteractionMember,
         },
     },
     channel::Attachment,
@@ -214,7 +214,7 @@ pub trait CommandOption: Sized {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType>;
 }
 
@@ -227,7 +227,7 @@ pub trait CommandOption: Sized {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommandInputData<'a> {
     pub options: Vec<CommandDataOption>,
-    pub resolved: Option<Cow<'a, CommandInteractionDataResolved>>,
+    pub resolved: Option<Cow<'a, InteractionDataResolved>>,
 }
 
 impl<'a> CommandInputData<'a> {
@@ -314,7 +314,7 @@ impl<'a> CommandInputData<'a> {
     /// subcommands.
     pub fn from_option(
         value: CommandOptionValue,
-        resolved: Option<&'a CommandInteractionDataResolved>,
+        resolved: Option<&'a InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let options = match value {
             CommandOptionValue::SubCommand(options)
@@ -401,7 +401,7 @@ impl CommandOption for CommandOptionValue {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         Ok(value)
     }
@@ -414,7 +414,7 @@ where
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Focused(value, _) => Ok(Self::Focused(value)),
@@ -431,7 +431,7 @@ impl CommandOption for String {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let value = match value {
             CommandOptionValue::String(value) => value,
@@ -458,7 +458,7 @@ impl<'a> CommandOption for Cow<'a, str> {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         String::from_option(value, data, resolved).map(Cow::Owned)
     }
@@ -468,7 +468,7 @@ impl CommandOption for i64 {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let value = match value {
             CommandOptionValue::Integer(value) => value,
@@ -495,7 +495,7 @@ impl CommandOption for f64 {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let value = match value {
             CommandOptionValue::Number(value) => value,
@@ -522,7 +522,7 @@ impl CommandOption for bool {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Boolean(value) => Ok(value),
@@ -535,7 +535,7 @@ impl CommandOption for Id<UserMarker> {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::User(value) => Ok(value),
@@ -548,7 +548,7 @@ impl CommandOption for Id<ChannelMarker> {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Channel(value) => Ok(value),
@@ -561,7 +561,7 @@ impl CommandOption for Id<RoleMarker> {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Role(value) => Ok(value),
@@ -574,7 +574,7 @@ impl CommandOption for Id<GenericMarker> {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Mentionable(value) => Ok(value),
@@ -587,7 +587,7 @@ impl CommandOption for Id<AttachmentMarker> {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        _resolved: Option<&CommandInteractionDataResolved>,
+        _resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         match value {
             CommandOptionValue::Attachment(value) => Ok(value),
@@ -600,7 +600,7 @@ impl CommandOption for Attachment {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let attachment_id = match value {
             CommandOptionValue::Attachment(value) => value,
@@ -615,7 +615,7 @@ impl CommandOption for User {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let user_id = match value {
             CommandOptionValue::User(value) => value,
@@ -630,7 +630,7 @@ impl CommandOption for ResolvedUser {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let user_id = match value {
             CommandOptionValue::User(value) => value,
@@ -648,7 +648,7 @@ impl CommandOption for ResolvedMentionable {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let id = match value {
             CommandOptionValue::Mentionable(value) => value,
@@ -678,7 +678,7 @@ impl CommandOption for InteractionChannel {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let resolved = match value {
             CommandOptionValue::Channel(value) => lookup!(resolved.channels, value)?,
@@ -699,7 +699,7 @@ impl CommandOption for Role {
     fn from_option(
         value: CommandOptionValue,
         _data: CommandOptionData,
-        resolved: Option<&CommandInteractionDataResolved>,
+        resolved: Option<&InteractionDataResolved>,
     ) -> Result<Self, ParseOptionErrorType> {
         let role_id = match value {
             CommandOptionValue::Role(value) => value,

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap};
 use twilight_model::{
     application::{
         command::{Command, CommandOption, CommandOptionType, CommandType},
-        interaction::application_command::InteractionChannel,
+        interaction::InteractionChannel,
     },
     channel::Attachment,
     guild::{Permissions, Role},

--- a/twilight-interactions/src/command/mod.rs
+++ b/twilight-interactions/src/command/mod.rs
@@ -74,7 +74,7 @@
 //! [`Cow`]: std::borrow::Cow
 //! [`User`]: twilight_model::user::User
 //! [`Id<UserMarker>`]: twilight_model::id::Id
-//! [`InteractionChannel`]: twilight_model::application::interaction::application_command::InteractionChannel
+//! [`InteractionChannel`]: twilight_model::application::interaction::InteractionChannel
 //! [`Id<ChannelMarker>`]: twilight_model::id::Id
 //! [`Role`]: twilight_model::guild::Role
 //! [`Id<RoleMarker>`]: twilight_model::id::Id

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -88,6 +88,8 @@ fn test_command_model() {
         verified: None,
         accent_color: None,
         banner: None,
+        avatar_decoration: None,
+        global_name: None,
     };
 
     let resolved_user = ResolvedUser {

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -4,8 +4,9 @@ use twilight_interactions::command::{
     CommandInputData, CommandModel, CommandOption, ResolvedMentionable, ResolvedUser,
 };
 use twilight_model::{
-    application::interaction::application_command::{
-        CommandDataOption, CommandInteractionDataResolved, CommandOptionValue, InteractionMember,
+    application::interaction::{
+        application_command::{CommandDataOption, CommandOptionValue},
+        InteractionDataResolved, InteractionMember,
     },
     guild::{MemberFlags, Permissions},
     id::Id,
@@ -61,7 +62,7 @@ fn test_command_model() {
     ];
 
     let member = InteractionMember {
-        joined_at: Timestamp::from_secs(1609455600).unwrap(),
+        joined_at: Some(Timestamp::from_secs(1609455600).unwrap()),
         nick: None,
         premium_since: None,
         roles: vec![],
@@ -97,7 +98,7 @@ fn test_command_model() {
         member: Some(member.clone()),
     };
 
-    let resolved = CommandInteractionDataResolved {
+    let resolved = InteractionDataResolved {
         channels: HashMap::new(),
         members: HashMap::from([(user_id, member)]),
         roles: HashMap::new(),

--- a/twilight-interactions/tests/create_command.rs
+++ b/twilight-interactions/tests/create_command.rs
@@ -6,7 +6,7 @@ use twilight_interactions::command::{
 use twilight_model::{
     application::{
         command::{CommandOption, CommandOptionType, CommandOptionValue},
-        interaction::application_command::InteractionChannel,
+        interaction::InteractionChannel,
     },
     channel::ChannelType,
     guild::Permissions,


### PR DESCRIPTION
Please note that because `twilight` is `=0.16.0-rc.1` at the time of this PR, `twilight-interactions` will also be `=0.16.0-rc.1`, meaning they will both be of an unstable release version.
This PR also updates the example bot, specifically in the main gateway handling code, as the gateway API in Twilight 0.16 has been greatly changed. It resembles the example in [`twilight_gateway`'s `README.md`](https://github.com/twilight-rs/twilight/tree/main/twilight-gateway#example).

Closes #34 