### PR TITLE
Version bump to twilight(-interactions)? 0.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest
     env:
-      minrust: "1.67"
+      minrust: "1.79"
 
     steps:
       - name: Checkout sources

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,11 +16,11 @@ tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "ansi"], default-features = false }
 
-twilight-gateway = "=0.16.0-rc.1"
-twilight-http = "=0.16.0-rc.1"
+twilight-gateway = "0.16.0"
+twilight-http = "0.16.0"
 twilight-interactions = { path = "../twilight-interactions" }
-twilight-model = "=0.16.0-rc.1"
-twilight-util = { version = "=0.16.0-rc.1", features = ["builder"] }
+twilight-model = "0.16.0"
+twilight-util = { version = "0.16.0", features = ["builder"] }
 
 [[example]]
 name = "xkcd-bot"

--- a/examples/xkcd-bot/main.rs
+++ b/examples/xkcd-bot/main.rs
@@ -93,7 +93,7 @@ async fn runner(mut shard: Shard, client: Arc<Client>) {
             Ok(event) => event,
             Err(error)
                 if SHUTDOWN.load(Ordering::Relaxed)
-                    && matches!(error.kind(), ReceiveMessageErrorType::WebSocket) =>
+                    && matches!(error.kind(), ReceiveMessageErrorType::Reconnect) =>
             {
                 break
             }

--- a/twilight-interactions-derive/Cargo.toml
+++ b/twilight-interactions-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilight-interactions-derive"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 description = "Macros and utilities to make Discord Interactions easy to use with Twilight."
 categories = ["parsing", "config", "asynchronous"]
 keywords = ["twilight", "discord", "slash-command"]

--- a/twilight-interactions-derive/Cargo.toml
+++ b/twilight-interactions-derive/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/baptiste0928/twilight-interactions#readme"
 repository = "https://github.com/baptiste0928/twilight-interactions"
 documentation = "https://docs.rs/twilight-interactions"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.79"
 license = "ISC"
 
 [lib]

--- a/twilight-interactions-derive/src/parse/attribute.rs
+++ b/twilight-interactions-derive/src/parse/attribute.rs
@@ -4,7 +4,7 @@
 //! - [`NamedAttrs`] parses a list of named attributes and allow to parse each
 //!   of them using a custom parser function.
 //! - [`ParseAttribute`] is used to parse a single attribute into a concrete
-//!  type.
+//!   type.
 
 use std::fmt::Display;
 

--- a/twilight-interactions/Cargo.toml
+++ b/twilight-interactions/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/baptiste0928/twilight-interactions#readme"
 repository = "https://github.com/baptiste0928/twilight-interactions"
 documentation = "https://docs.rs/twilight-interactions"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.79"
 license = "ISC"
 include = ["src/**/*", "README.md"]
 

--- a/twilight-interactions/Cargo.toml
+++ b/twilight-interactions/Cargo.toml
@@ -19,8 +19,8 @@ default = ["derive"]
 derive = ["twilight-interactions-derive"]
 
 [dependencies]
-twilight-model = "=0.16.0-rc.1"
-twilight-interactions-derive = { version = "=0.16.0-rc.1", path = "../twilight-interactions-derive", optional = true }
+twilight-model = "0.16.0"
+twilight-interactions-derive = { version = "=0.16.0", path = "../twilight-interactions-derive", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -467,7 +467,7 @@ impl CommandOption for String {
     }
 }
 
-impl<'a> CommandOption for Cow<'a, str> {
+impl CommandOption for Cow<'_, str> {
     fn from_option(
         value: CommandOptionValue,
         data: CommandOptionData,

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -245,6 +245,7 @@ pub struct ApplicationCommandData {
 
 impl From<ApplicationCommandData> for Command {
     fn from(item: ApplicationCommandData) -> Self {
+        #[expect(deprecated)]
         Command {
             application_id: None,
             guild_id: None,
@@ -259,6 +260,8 @@ impl From<ApplicationCommandData> for Command {
             nsfw: item.nsfw,
             options: item.options,
             version: Id::new(1),
+            contexts: None,
+            integration_types: None,
         }
     }
 }

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -245,7 +245,7 @@ pub struct ApplicationCommandData {
 
 impl From<ApplicationCommandData> for Command {
     fn from(item: ApplicationCommandData) -> Self {
-        #[expect(deprecated)]
+        #[allow(deprecated)]
         Command {
             application_id: None,
             guild_id: None,

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -295,7 +295,7 @@ impl CreateOption for String {
     }
 }
 
-impl<'a> CreateOption for Cow<'a, str> {
+impl CreateOption for Cow<'_, str> {
     fn create_option(data: CreateOptionData) -> CommandOption {
         data.into_option(CommandOptionType::String)
     }

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -139,7 +139,6 @@ impl<T: CreateCommand> CreateCommand for Box<T> {
 /// [^localization]: Path to a function that returns a type that implements
 ///                  `IntoIterator<Item = (ToString, ToString)>`. See the
 ///                  [module documentation](crate::command) to learn more.
-
 pub trait CreateOption: Sized {
     /// Create a [`CommandOption`] from this type.
     fn create_option(data: CreateOptionData) -> CommandOption;

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -91,6 +91,7 @@ fn test_command_model() {
         banner: None,
         avatar_decoration: None,
         global_name: None,
+        avatar_decoration_data: None
     };
 
     let resolved_user = ResolvedUser {

--- a/twilight-interactions/tests/command_model.rs
+++ b/twilight-interactions/tests/command_model.rs
@@ -91,7 +91,7 @@ fn test_command_model() {
         banner: None,
         avatar_decoration: None,
         global_name: None,
-        avatar_decoration_data: None
+        avatar_decoration_data: None,
     };
 
     let resolved_user = ResolvedUser {


### PR DESCRIPTION
This PR does *not* implement new features! it only bumps the compatible versions- a point release can be made in the future to support the new `contexts` and `integration_types` fields.