### PR TITLE
feat: add support for `contexts` and `integration_types` attributes in `CreateCommand`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,11 +14,7 @@ futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = [
-    "std",
-    "fmt",
-    "ansi",
-], default-features = false }
+tracing-subscriber = { version = "0.3", features = ["std", "fmt", "ansi"], default-features = false }
 
 twilight-gateway = "0.16.0"
 twilight-http = "0.16.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,11 @@ futures-util = { version = "0.3", default-features = false }
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["std", "fmt", "ansi"], default-features = false }
+tracing-subscriber = { version = "0.3", features = [
+    "std",
+    "fmt",
+    "ansi",
+], default-features = false }
 
 twilight-gateway = "0.16.0"
 twilight-http = "0.16.0"

--- a/examples/xkcd-bot/main.rs
+++ b/examples/xkcd-bot/main.rs
@@ -18,8 +18,7 @@ use std::{
 use anyhow::Context;
 use tracing::Level;
 use twilight_gateway::{
-    error::ReceiveMessageErrorType, CloseFrame, ConfigBuilder, Event, EventTypeFlags, Intents,
-    Shard, StreamExt as _,
+    CloseFrame, ConfigBuilder, Event, EventTypeFlags, Intents, Shard, StreamExt as _,
 };
 use twilight_http::Client;
 use twilight_interactions::command::CreateCommand;
@@ -91,12 +90,6 @@ async fn runner(mut shard: Shard, client: Arc<Client>) {
         let event = match item {
             Ok(Event::GatewayClose(_)) if SHUTDOWN.load(Ordering::Relaxed) => break,
             Ok(event) => event,
-            Err(error)
-                if SHUTDOWN.load(Ordering::Relaxed)
-                    && matches!(error.kind(), ReceiveMessageErrorType::Reconnect) =>
-            {
-                break
-            }
             Err(error) => {
                 tracing::warn!(?error, "error while receiving event");
                 continue;

--- a/twilight-interactions-derive/src/command/mod.rs
+++ b/twilight-interactions-derive/src/command/mod.rs
@@ -4,6 +4,7 @@ mod impls;
 
 mod model;
 mod subcommand;
+mod user_application;
 
 pub use impls::{
     dummy_command_model, dummy_create_command, impl_command_model, impl_create_command,

--- a/twilight-interactions-derive/src/command/model/parse.rs
+++ b/twilight-interactions-derive/src/command/model/parse.rs
@@ -4,10 +4,13 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{spanned::Spanned, Attribute, Error, Lit, Result, Type};
 
-use crate::parse::{
-    attribute::{NamedAttrs, ParseAttribute, ParseSpanned},
-    parsers::{CommandDescription, CommandName, FunctionPath},
-    syntax::{extract_generic, find_attr},
+use crate::{
+    command::user_application::{ApplicationIntegrationType, InteractionContextType},
+    parse::{
+        attribute::{NamedAttrs, ParseAttribute, ParseSpanned},
+        parsers::{CommandDescription, CommandName, FunctionPath},
+        syntax::{extract_generic, find_attr},
+    },
 };
 
 /// Parsed struct field
@@ -102,6 +105,10 @@ pub struct TypeAttribute {
     pub dm_permission: Option<bool>,
     /// Whether the command is nsfw.
     pub nsfw: Option<bool>,
+    /// Interaction context(s) where the command can be used.
+    pub contexts: Option<Vec<InteractionContextType>>,
+    /// Installation contexts where the command is available.
+    pub integration_types: Option<Vec<ApplicationIntegrationType>>,
 }
 
 impl TypeAttribute {
@@ -114,6 +121,8 @@ impl TypeAttribute {
         "default_permissions",
         "dm_permission",
         "nsfw",
+        "contexts",
+        "integration_types",
     ];
 
     pub fn parse(attr: &Attribute) -> Result<Self> {
@@ -128,6 +137,8 @@ impl TypeAttribute {
             default_permissions: parser.optional("default_permissions")?,
             dm_permission: parser.optional("dm_permission")?,
             nsfw: parser.optional("nsfw")?,
+            contexts: parser.optional("contexts")?,
+            integration_types: parser.optional("integration_types")?,
         })
     }
 }

--- a/twilight-interactions-derive/src/command/subcommand/create_command.rs
+++ b/twilight-interactions-derive/src/command/subcommand/create_command.rs
@@ -4,6 +4,7 @@ use syn::{spanned::Spanned, DeriveInput, Error, Result, Variant};
 
 use super::parse::{ParsedVariant, TypeAttribute};
 use crate::{
+    command::user_application::{context, integration_type},
     localization::{description_expr, name_expr},
     parse::syntax::{find_attr, optional, parse_doc},
 };
@@ -45,6 +46,20 @@ pub fn impl_create_command(
 
     let variant_options = variants.iter().map(variant_option);
 
+    let contexts = if let Some(items) = attributes.contexts {
+        let items = items.iter().map(context);
+        quote! { ::std::option::Option::Some(::std::vec![#(#items),*]) }
+    } else {
+        quote! { ::std::option::Option::None }
+    };
+
+    let integration_types = if let Some(items) = attributes.integration_types {
+        let items = items.iter().map(integration_type);
+        quote! { ::std::option::Option::Some(::std::vec![#(#items),*]) }
+    } else {
+        quote! { ::std::option::Option::None }
+    };
+
     Ok(quote! {
         impl #generics ::twilight_interactions::command::CreateCommand for #ident #generics #where_clause {
             const NAME: &'static str = #name;
@@ -66,6 +81,8 @@ pub fn impl_create_command(
                     dm_permission: #dm_permission,
                     nsfw: #nsfw,
                     group: true,
+                    contexts: #contexts,
+                    integration_types: #integration_types,
                 }
             }
         }

--- a/twilight-interactions-derive/src/command/subcommand/parse.rs
+++ b/twilight-interactions-derive/src/command/subcommand/parse.rs
@@ -1,10 +1,13 @@
 use proc_macro2::{Ident, Span};
 use syn::{spanned::Spanned, Attribute, Error, Fields, Result, Type, TypePath, Variant};
 
-use crate::parse::{
-    attribute::NamedAttrs,
-    parsers::{CommandDescription, CommandName, FunctionPath},
-    syntax::find_attr,
+use crate::{
+    command::user_application::{ApplicationIntegrationType, InteractionContextType},
+    parse::{
+        attribute::NamedAttrs,
+        parsers::{CommandDescription, CommandName, FunctionPath},
+        syntax::find_attr,
+    },
 };
 
 /// Parsed enum variant
@@ -109,6 +112,10 @@ pub struct TypeAttribute {
     pub dm_permission: Option<bool>,
     /// Whether the command is nsfw.
     pub nsfw: Option<bool>,
+    /// Interaction context(s) where the command can be used.
+    pub contexts: Option<Vec<InteractionContextType>>,
+    /// Installation contexts where the command is available.
+    pub integration_types: Option<Vec<ApplicationIntegrationType>>,
 }
 
 impl TypeAttribute {
@@ -120,6 +127,8 @@ impl TypeAttribute {
         "default_permissions",
         "dm_permission",
         "nsfw",
+        "contexts",
+        "integration_types",
     ];
 
     pub fn parse(attr: &Attribute) -> Result<Self> {
@@ -133,6 +142,8 @@ impl TypeAttribute {
             default_permissions: parser.optional("default_permissions")?,
             dm_permission: parser.optional("dm_permission")?,
             nsfw: parser.optional("nsfw")?,
+            contexts: parser.optional("contexts")?,
+            integration_types: parser.optional("integration_types")?,
         })
     }
 }

--- a/twilight-interactions-derive/src/command/user_application.rs
+++ b/twilight-interactions-derive/src/command/user_application.rs
@@ -1,0 +1,100 @@
+//! Parsing of user applications related structs.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Error, Lit, Result};
+
+use crate::parse::attribute::{ParseAttribute, ParseSpanned};
+
+/// Parsed interaction context type
+pub enum InteractionContextType {
+    Guild,
+    BotDm,
+    PrivateChannel,
+}
+
+impl ParseAttribute for Vec<InteractionContextType> {
+    fn parse_attribute(input: Lit) -> Result<Self> {
+        let spanned: ParseSpanned<String> = ParseAttribute::parse_attribute(input)?;
+
+        spanned
+            .inner
+            .split_ascii_whitespace()
+            .map(|value| InteractionContextType::parse(value, spanned.span))
+            .collect()
+    }
+}
+
+impl InteractionContextType {
+    fn parse(value: &str, span: Span) -> Result<Self> {
+        match value {
+            "guild" => Ok(Self::Guild),
+            "bot_dm" => Ok(Self::BotDm),
+            "private_channel" => Ok(Self::PrivateChannel),
+            invalid => Err(Error::new(
+                span,
+                format!("`{invalid}` is not a valid context type"),
+            )),
+        }
+    }
+}
+
+/// Parsed application integration type
+pub enum ApplicationIntegrationType {
+    GuildInstall,
+    UserInstall,
+}
+
+impl ParseAttribute for Vec<ApplicationIntegrationType> {
+    fn parse_attribute(input: Lit) -> Result<Self> {
+        let spanned: ParseSpanned<String> = ParseAttribute::parse_attribute(input)?;
+
+        spanned
+            .inner
+            .split_ascii_whitespace()
+            .map(|value| ApplicationIntegrationType::parse(value, spanned.span))
+            .collect()
+    }
+}
+
+impl ApplicationIntegrationType {
+    fn parse(value: &str, span: Span) -> Result<Self> {
+        match value {
+            "guild_install" => Ok(Self::GuildInstall),
+            "user_install" => Ok(Self::UserInstall),
+            invalid => Err(Error::new(
+                span,
+                format!("`{invalid}` is not a valid integration type"),
+            )),
+        }
+    }
+}
+
+/// Convert a [`InteractionContextType`] into a [`TokenStream`]
+pub fn context(kind: &InteractionContextType) -> TokenStream {
+    match kind {
+        InteractionContextType::Guild => {
+            quote!(::twilight_model::application::interaction::InteractionContextType::Guild)
+        }
+        InteractionContextType::BotDm => {
+            quote!(::twilight_model::application::interaction::InteractionContextType::BotDm)
+        }
+        InteractionContextType::PrivateChannel => {
+            quote!(
+                ::twilight_model::application::interaction::InteractionContextType::PrivateChannel
+            )
+        }
+    }
+}
+
+/// Convert a [`ApplicationIntegrationType`] into a [`TokenStream`]
+pub fn integration_type(kind: &ApplicationIntegrationType) -> TokenStream {
+    match kind {
+        ApplicationIntegrationType::GuildInstall => {
+            quote!(::twilight_model::oauth::ApplicationIntegrationType::GuildInstall)
+        }
+        ApplicationIntegrationType::UserInstall => {
+            quote!(::twilight_model::oauth::ApplicationIntegrationType::UserInstall)
+        }
+    }
+}

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -59,20 +59,22 @@ use super::{internal::CreateOptionData, ResolvedMentionable, ResolvedUser};
 /// The macro provides a `#[command]` attribute to provide additional
 /// information.
 ///
-/// | Attribute                  | Type                | Location               | Description                                                     |
-/// |----------------------------|---------------------|------------------------|-----------------------------------------------------------------|
-/// | `name`                     | `str`               | Type                   | Name of the command (required).                                 |
-/// | `desc`                     | `str`               | Type / Field / Variant | Description of the command (required).                          |
-/// | `default_permissions`      | `fn`[^perms]        | Type                   | Default permissions required by members to run the command.     |
-/// | `dm_permission`            | `bool`              | Type                   | Whether the command can be run in DMs.                          |
-/// | `nsfw`                     | `bool`              | Type                   | Whether the command is age-restricted.
-/// | `rename`                   | `str`               | Field                  | Use a different option name than the field name.                |
-/// | `name_localizations`       | `fn`[^localization] | Type / Field / Variant | Localized name of the command (optional).                       |
-/// | `desc_localizations`       | `fn`[^localization] | Type / Field / Variant | Localized description of the command (optional).                |
-/// | `autocomplete`             | `bool`              | Field                  | Enable autocomplete on this field.                              |
-/// | `channel_types`            | `str`               | Field                  | Restricts the channel choice to specific types.[^channel_types] |
-/// | `max_value`, `min_value`   | `i64` or `f64`      | Field                  | Set the maximum and/or minimum value permitted.                 |
-/// | `max_length`, `min_length` | `u16`               | Field                  |   Maximum and/or minimum string length permitted.               |
+/// | Attribute                  | Type                | Location               | Description                                                               |
+/// |----------------------------|---------------------|------------------------|---------------------------------------------------------------------------|
+/// | `name`                     | `str`               | Type                   | Name of the command (required).                                           |
+/// | `desc`                     | `str`               | Type / Field / Variant | Description of the command (required).                                    |
+/// | `default_permissions`      | `fn`[^perms]        | Type                   | Default permissions required by members to run the command.               |
+/// | `dm_permission`            | `bool`              | Type                   | Whether the command can be run in DMs.                                    |
+/// | `nsfw`                     | `bool`              | Type                   | Whether the command is age-restricted.                                    |
+/// | `rename`                   | `str`               | Field                  | Use a different option name than the field name.                          |
+/// | `name_localizations`       | `fn`[^localization] | Type / Field / Variant | Localized name of the command (optional).                                 |
+/// | `desc_localizations`       | `fn`[^localization] | Type / Field / Variant | Localized description of the command (optional).                          |
+/// | `autocomplete`             | `bool`              | Field                  | Enable autocomplete on this field.                                        |
+/// | `channel_types`            | `str`               | Field                  | Restricts the channel choice to specific types.[^channel_types]           |
+/// | `max_value`, `min_value`   | `i64` or `f64`      | Field                  | Set the maximum and/or minimum value permitted.                           |
+/// | `max_length`, `min_length` | `u16`               | Field                  | Maximum and/or minimum string length permitted.                           |
+/// | `contexts`                 | `str`               | Type                   | Interaction context(s) where the command can be used.[^contexts]          |
+/// | `integration_types`        | `str`               | Type                   | Installation contexts where the command is available.[^integration_types] |
 ///
 /// [^perms]: Path to a function that returns [`Permissions`]. Permissions can
 /// only be set on top-level commands
@@ -84,8 +86,16 @@ use super::{internal::CreateOptionData, ResolvedMentionable, ResolvedUser};
 /// [^channel_types]: List of [`ChannelType`] names in snake_case separated by spaces
 /// like `guild_text private`.
 ///
+/// [^contexts]: List of [`InteractionContextType`] names in snake_case separated by
+/// spaces like `guild private_channel`.
+///
+/// [^integration_types]: List of [`ApplicationIntegrationType`] names in snake_case
+/// separated by spaces like `guild_install user_install`.
+///
 /// [`CommandModel`]: super::CommandModel
 /// [`ChannelType`]: twilight_model::channel::ChannelType
+/// [`InteractionContextType`]: twilight_model::application::interaction::InteractionContextType
+/// [`ApplicationIntegrationType`]: twilight_model::oauth::ApplicationIntegrationType
 pub trait CreateCommand: Sized {
     /// Name of the command.
     const NAME: &'static str;

--- a/twilight-interactions/src/command/create_command.rs
+++ b/twilight-interactions/src/command/create_command.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap};
 use twilight_model::{
     application::{
         command::{Command, CommandOption, CommandOptionType, CommandType},
-        interaction::InteractionChannel,
+        interaction::{InteractionChannel, InteractionContextType},
     },
     channel::Attachment,
     guild::{Permissions, Role},
@@ -11,6 +11,7 @@ use twilight_model::{
         marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
         Id,
     },
+    oauth::ApplicationIntegrationType,
     user::User,
 };
 
@@ -233,6 +234,7 @@ pub struct ApplicationCommandData {
     /// List of command options.
     pub options: Vec<CommandOption>,
     /// Whether the command is available in DMs.
+    #[deprecated(note = "use contexts instead")]
     pub dm_permission: Option<bool>,
     /// Default permissions required for a member to run the command.
     pub default_member_permissions: Option<Permissions>,
@@ -240,6 +242,10 @@ pub struct ApplicationCommandData {
     pub group: bool,
     /// Whether the command is nsfw.
     pub nsfw: Option<bool>,
+    /// Interaction context(s) where the command can be used.
+    pub contexts: Option<Vec<InteractionContextType>>,
+    /// Installation contexts where the command is available.
+    pub integration_types: Option<Vec<ApplicationIntegrationType>>,
 }
 
 impl From<ApplicationCommandData> for Command {
@@ -259,8 +265,8 @@ impl From<ApplicationCommandData> for Command {
             nsfw: item.nsfw,
             options: item.options,
             version: Id::new(1),
-            contexts: None,
-            integration_types: None,
+            contexts: item.contexts,
+            integration_types: item.integration_types,
         }
     }
 }

--- a/twilight-interactions/tests/create_command.rs
+++ b/twilight-interactions/tests/create_command.rs
@@ -165,6 +165,7 @@ fn test_create_command() {
 
     let name_localizations = HashMap::from([("en".into(), "demo".into())]);
 
+    #[allow(deprecated)]
     let expected = ApplicationCommandData {
         name: "demo".into(),
         name_localizations: Some(name_localizations),
@@ -175,6 +176,8 @@ fn test_create_command() {
         dm_permission: Some(false),
         group: false,
         nsfw: Some(true),
+        contexts: None,
+        integration_types: None,
     };
 
     assert_eq!(DemoCommand::<i64>::create_command(), expected);
@@ -183,6 +186,7 @@ fn test_create_command() {
 
 #[test]
 fn test_unit_create_command() {
+    #[allow(deprecated)]
     let expected = ApplicationCommandData {
         name: "unit".into(),
         name_localizations: None,
@@ -193,6 +197,8 @@ fn test_unit_create_command() {
         dm_permission: None,
         group: false,
         nsfw: None,
+        contexts: None,
+        integration_types: None,
     };
 
     assert_eq!(UnitCommand::create_command(), expected);

--- a/twilight-interactions/tests/create_command.rs
+++ b/twilight-interactions/tests/create_command.rs
@@ -7,10 +7,11 @@ use twilight_interactions::command::{
 use twilight_model::{
     application::{
         command::{CommandOption, CommandOptionType, CommandOptionValue},
-        interaction::InteractionChannel,
+        interaction::{InteractionChannel, InteractionContextType},
     },
     channel::ChannelType,
     guild::Permissions,
+    oauth::ApplicationIntegrationType,
 };
 
 /// Demo command for testing purposes
@@ -20,6 +21,8 @@ use twilight_model::{
     name_localizations = "demo_name",
     default_permissions = "demo_permissions",
     dm_permission = false,
+    contexts = "guild private_channel",
+    integration_types = "guild_install",
     nsfw = true
 )]
 struct DemoCommand<'a, T>
@@ -176,8 +179,11 @@ fn test_create_command() {
         dm_permission: Some(false),
         group: false,
         nsfw: Some(true),
-        contexts: None,
-        integration_types: None,
+        contexts: Some(vec![
+            InteractionContextType::Guild,
+            InteractionContextType::PrivateChannel,
+        ]),
+        integration_types: Some(vec![ApplicationIntegrationType::GuildInstall]),
     };
 
     assert_eq!(DemoCommand::<i64>::create_command(), expected);

--- a/twilight-interactions/tests/subcommand.rs
+++ b/twilight-interactions/tests/subcommand.rs
@@ -210,6 +210,7 @@ fn test_create_subcommand() {
         },
     ];
 
+    #[allow(deprecated)]
     let expected = ApplicationCommandData {
         name: "command".into(),
         name_localizations: None,
@@ -220,6 +221,8 @@ fn test_create_subcommand() {
         dm_permission: None,
         group: true,
         nsfw: None,
+        contexts: None,
+        integration_types: None,
     };
 
     assert_eq!(SubCommand::create_command(), expected);


### PR DESCRIPTION
This PR adds support for two new optional attributes in `CreateCommand`: `contexts` and `integration_types`, which will be parsed and stored in the `ApplicationCommandData` struct and subsequently used to create a `Command` object. 

Note that the `dm_permission` field in `Command` is still supported but deprecated, yet this PR does not include any code that will give any deprecation warning to the user if they choose to use the `dm_permission` attribute anyways.

The code has been tested in a Discord bot's codebase, but additional testing should be done regardless.

cc @randomairborne 