### PR TITLE
Fix compile error from `into` ambiguity

### DIFF
--- a/twilight-interactions/Cargo.toml
+++ b/twilight-interactions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilight-interactions"
-version = "0.16.1"
+version = "0.16.2"
 description = "Macros and utilities to make Discord Interactions easy to use with Twilight."
 categories = ["parsing", "config", "asynchronous"]
 keywords = ["twilight", "discord", "slash-command"]

--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -452,13 +452,13 @@ impl CommandOption for String {
         };
 
         if let Some(min) = data.min_length {
-            if value.len() < min.into() {
+            if value.len() < usize::from(min) {
                 todo!()
             }
         }
 
         if let Some(max) = data.max_length {
-            if value.len() > max.into() {
+            if value.len() > usize::from(max) {
                 todo!()
             }
         }


### PR DESCRIPTION
It seems like `deranged` had an update that created an ambiguity with `into`. This trivially fixes that.