### PR TITLE
fix string length validation using char count instead of byte length

### DIFF
--- a/twilight-interactions/src/command/command_model.rs
+++ b/twilight-interactions/src/command/command_model.rs
@@ -455,15 +455,17 @@ impl CommandOption for String {
             other => return Err(ParseOptionErrorType::InvalidType(other.kind())),
         };
 
+        let char_len = value.chars().count();
+
         if let Some(min) = data.min_length {
-            if value.len() < usize::from(min) {
-                todo!()
+            if char_len < usize::from(min) {
+                return Err(ParseOptionErrorType::StringLengthOutOfRange(value));
             }
         }
 
         if let Some(max) = data.max_length {
-            if value.len() > usize::from(max) {
-                todo!()
+            if char_len > usize::from(max) {
+                return Err(ParseOptionErrorType::StringLengthOutOfRange(value));
             }
         }
 


### PR DESCRIPTION
Discord validates string option lengtsh using Unicode character count (same as Python's `len()`), not byte count. The current impülementation uses `value.len()` which returns the UTF-8 byte length in Rust, causing false validation failures for strings containing multibyte characters (accented letters, CJK characters, emojis, etc.) that are otherwise within Discord's limit.

This also replaces the `todo!()` stubs with proper `ParseOptionErrorType::StringLengthOutOfRange` errors.